### PR TITLE
Replace deprecated deadline flag with timeout

### DIFF
--- a/app/analyze/linters/golinters/golangci_lint.go
+++ b/app/analyze/linters/golinters/golangci_lint.go
@@ -30,7 +30,7 @@ func (g GolangciLint) Run(ctx context.Context, exec executors.Executor) (*result
 		"--out-format=json",
 		"--issues-exit-code=0",
 		"--print-welcome=false",
-		"--deadline=5m",
+		"--timeout=5m",
 		"--new=false",
 		"--new-from-rev=",
 		"--new-from-patch=" + g.PatchPath,


### PR DESCRIPTION
The `--deadline` flag has been marked as deprecated in https://github.com/golangci/golangci-lint/pull/793. 