### PR TITLE
Use --timeout instead of depcreated --deadline in anaylize

### DIFF
--- a/app/analyze/linters/golinters/golangci_lint.go
+++ b/app/analyze/linters/golinters/golangci_lint.go
@@ -30,7 +30,7 @@ func (g GolangciLint) Run(ctx context.Context, exec executors.Executor) (*result
 		"--out-format=json",
 		"--issues-exit-code=0",
 		"--print-welcome=false",
-		"--deadline=5m",
+		"--timeout=5m",
 		"--new=false",
 		"--new-from-rev=",
 		"--new-from-patch=" + g.PatchPath,


### PR DESCRIPTION
The deprecation notice is printed to stdout, making the output invalid JSON.

See for example this build: https://golangci.com/r/github.com/secrethub/secrethub-cli/pulls/201